### PR TITLE
Allow explicit string filters to be used in fuzzy match.

### DIFF
--- a/Tests/FilterTests/FilterTests.cs
+++ b/Tests/FilterTests/FilterTests.cs
@@ -422,5 +422,18 @@ namespace Tests.FilterTestGoup
             filtered = orders.Filter(filter).Resolve();
             filtered.Value.Count().Should().Be(1);
         }
+
+        [Fact]
+        public void FuzzyMatchIncludesExplicitStringFilter()
+        {
+            var repo = ServiceProvider.GetService<FakeRepo>();
+            SeedData();
+
+            // Should return FirstName matching Bob
+            var filter = new UserFilter { FirstName = "Bob", FuzzyMatchTerm = "Bo" };
+            var users = repo.GetQueryable<User>();
+            var filtered = users.Filter(filter).Resolve();
+            filtered.Value.Count().Should().Be(2);
+        }
     }
 }

--- a/src/Filters/Filter.cs
+++ b/src/Filters/Filter.cs
@@ -176,7 +176,8 @@ namespace EFCoreSugar.Filters
                         predicate = subPredicate;
                     }
                 }
-                else if(filterProp.FuzzyMatchMode != FuzzyMatchMode.None && !string.IsNullOrWhiteSpace(FuzzyMatchTerm) && filterProp.Property.PropertyType == typeof(string))
+
+                if(filterProp.FuzzyMatchMode != FuzzyMatchMode.None && !string.IsNullOrWhiteSpace(FuzzyMatchTerm) && filterProp.Property.PropertyType == typeof(string))
                 {
                     var subPredicate = BuildPredicate<T>(entityParam, entityParam, filterProp, FuzzyMatchFormats[filterProp.FuzzyMatchMode](FuzzyMatchTerm), true);
                     fuzzyMatchPredicate = fuzzyMatchPredicate?.Or(subPredicate) ?? subPredicate;


### PR DESCRIPTION
This fixes fuzzy match when an explicit string filter is defined. Previously, if a string filter was defined, fuzzy match would not search over that string value.